### PR TITLE
Fix .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,7 +5,8 @@ name = "go"
 enabled = true
 
   [analyzers.meta]
-  import_paths = ["github.com/jlk/webapp-base"]
+  import_paths = ["github.com/jlk/webapp-base/server"]
+  import_root = "github.com/jlk/webapp-base"
 
 [[analyzers]]
 name = "javascript"


### PR DESCRIPTION
In cases where the `go.mod` file is not in the root of the repo, `import_root` must be set, and `import_paths` should specify the individual paths where `go.mod` exists.